### PR TITLE
chore: update cd GHA and README

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: CD
 
 on:
   push:
@@ -24,18 +24,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Release
+        uses: cycjimmy/semantic-release-action@v4
+        id: semantic
         env:
-          DEBUG: semantic-release:*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
       - name: Setup Java
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21
       - name: Setup Gradle
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: gradle/actions/setup-gradle@v4
       - name: Publish to Gradle - Plugins
+        if: steps.semantic.outputs.new_release_published == 'true'
         run: ./gradlew publishPlugins
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/.releaserc
+++ b/.releaserc
@@ -7,6 +7,12 @@
         "replacements": [
           {
             "files": ["README.md"],
+            "from": "\\s*id\\(\"io\\.oczadly\\.springinitializr\"\\) version \"([^\"]*)\"",
+            "to": "\n    id(\"io.oczadly.springinitializr\") version \"${nextRelease.version}\"",
+            "regex": true
+          },
+          {
+            "files": ["README.md"],
             "from": "\\s*id 'io\\.oczadly\\.springinitializr' version '([^']*)'",
             "to": "\n    id 'io.oczadly.springinitializr' version '${nextRelease.version}'",
             "regex": true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gradle-springinitializr-plugin
 
-[![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/springinitializr?logo=gradle)](https://plugins.gradle.org/plugin/io.oczadly.springinitializr)
+[![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/io.oczadly.springinitializr?logo=gradle)](https://plugins.gradle.org/plugin/io.oczadly.springinitializr)
 [![Latest Release](https://img.shields.io/github/v/release/paweloczadly/gradle-springinitializr-plugin?label=release)](https://github.com/paweloczadly/gradle-springinitializr-plugin/releases/latest)
 
 A **production-grade Gradle plugin** for **bootstrapping Spring Boot projects locally** using the [Spring Initializr API](https://start.spring.io), supporting **project metadata, build cache, and CI-friendly workflows**.
@@ -19,7 +19,7 @@ Add to your `build.gradle.kts` (Kotlin DSL):
 
 ```kotlin
 plugins {
-    id("io.oczadly.springinitializr") version "0.0.1"
+    id("io.oczadly.springinitializr") version "1.0.0"
 }
 ```
 


### PR DESCRIPTION
# Pull Request

## 🚀 What was changed

* Updates CD GitHub Action by conditionally publish the plugin when new GitHub release is created.
* Fixes replacing plugin version in the Kotlin DSL.
* Fixes plugin portal badge.

## ✅ Checklist

- [x] My change is **well-scoped** (one logical change).
- [x] I have **updated/added tests** if needed.
- [x] I have **updated the README/CHANGELOG** if needed.
- [x] I ran:
  ```bash
  ./gradlew build
  ```
- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

## 🧩 Related issues (optional)

<!-- Link to relevant issues, e.g., Closes ... -->
