### PR TITLE
chore(doc): add 'IMPORTANT' blocks to CONTRIBUTING and FAQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ Please be respectful and constructive in your communication. Contributions are w
 
 ## ⚠️ Maintainer note
 
+> [!IMPORTANT]
 > This plugin is developed and maintained in **focused time blocks** to ensure high quality. Contributions and issues will be addressed on a **best-effort basis**, depending on ongoing priorities.
 
 Thank you for helping make **gradle-springinitializr-plugin** better! 🚀

--- a/FAQ.md
+++ b/FAQ.md
@@ -85,13 +85,15 @@ Please run Gradle with `--stacktrace --info`. You’ll see request/response logs
 
 Yes! Please use the [feature request templates](https://github.com/paweloczadly/gradle-springinitializr-plugin/issues/new?template=10_feature_request.yaml) to request a new feature. Note, however, that:
 
-> ⚠️ This plugin is developed and maintained in **focused time blocks** to ensure quality. Updates may be addressed on a **best-effort basis**.
+> [!IMPORTANT]
+> This plugin is developed and maintained in **focused time blocks** to ensure quality. Updates may be addressed on a **best-effort basis**.
 
 ## Can I report a bug?
 
 Yes! Please use the [bug report templates](https://github.com/paweloczadly/gradle-springinitializr-plugin/issues/new?template=20_bug_report.yaml) to report a clear and reproducible issue.
 
-> ⚠️ This plugin is developed and maintained in focused time blocks to ensure quality. Bug reports will be reviewed and addressed on a best-effort basis, depending on ongoing priorities.
+> [!IMPORTANT]
+> This plugin is developed and maintained in focused time blocks to ensure quality. Bug reports will be reviewed and addressed on a best-effort basis, depending on ongoing priorities.
 
 ## How do I contribute?
 


### PR DESCRIPTION
# Pull Request

## 🚀 What was changed

Improves readability of CONTRIBUTING and FAQ docs, by adding 'IMPORTANT' blocks to maintainer note sections.

## ✅ Checklist

- [x] My change is **well-scoped** (one logical change).
- [x] I have **updated/added tests** if needed.
- [x] I have **updated the README/CHANGELOG** if needed.
- [x] I ran:
  ```bash
  ./gradlew build
  ```
- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

## 🧩 Related issues (optional)

<!-- Link to relevant issues, e.g., Closes ... -->
