### PR TITLE
chore(doc): add 'NOTE' block to Installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A **production-grade Gradle plugin** for **bootstrapping Spring Boot projects lo
 
 ## 📦 Installation
 
-> **Note:** Versioning is managed automatically via Git tags and [semantic-release](https://semantic-release.gitbook.io/semantic-release/), with `build.gradle` containing a placeholder version.
+> [!NOTE]
+> Versioning is managed automatically via Git tags and [semantic-release](https://semantic-release.gitbook.io/semantic-release/), with `build.gradle` containing a placeholder version.
 
 Add to your `build.gradle.kts` (Kotlin DSL):
 


### PR DESCRIPTION
# Pull Request

## 🚀 What was changed

Improves readability of README by adding the 'NOTE' block to the Installation section. 

## ✅ Checklist

- [x] My change is **well-scoped** (one logical change).
- [x] I have **updated/added tests** if needed.
- [x] I have **updated the README/CHANGELOG** if needed.
- [x] I ran:
  ```bash
  ./gradlew build
  ```
- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

## 🧩 Related issues (optional)

<!-- Link to relevant issues, e.g., Closes ... -->
