### PR TITLE
fix: adjust default class name and add RC Spring Boot version handling

### DIFF
--- a/plugin/src/functionalTest/groovy/io/oczadly/internal/generator/SpringBootProjectGeneratorFunctionalSpec.groovy
+++ b/plugin/src/functionalTest/groovy/io/oczadly/internal/generator/SpringBootProjectGeneratorFunctionalSpec.groovy
@@ -59,7 +59,7 @@ class SpringBootProjectGeneratorFunctionalSpec extends Specification {
         then:
         FilesTestUtils.zipFileExistsAndNotEmpty outputZip
         FilesTestUtils.projectFilesExist unzipDir, 'build.gradle.kts'
-        FilesTestUtils.projectFilesExist unzipDir, 'src/main/kotlin/io/oczadly/myspringapp/DemoApplication.kt'
+        FilesTestUtils.projectFilesExist unzipDir, 'src/main/kotlin/io/oczadly/myspringapp/MyspringappApplication.kt'
     }
 
     def 'generate should only download project without extracting'() {

--- a/plugin/src/main/groovy/io/oczadly/internal/utils/BootVersionUtils.groovy
+++ b/plugin/src/main/groovy/io/oczadly/internal/utils/BootVersionUtils.groovy
@@ -10,19 +10,19 @@ import java.util.regex.Pattern
 class BootVersionUtils {
 
     private static final String CORE = '\\d+\\.\\d+\\.\\d+'
-    private static final String REGEX = "^${CORE}(?:\\.(?:RELEASE|BUILD-SNAPSHOT|M\\d+)|-(?:RELEASE|SNAPSHOT|M\\d+))?\$"
+    private static final String REGEX = "^${CORE}(?:\\.(?:RELEASE|BUILD-SNAPSHOT|M\\d+|RC\\d+)|-(?:RELEASE|SNAPSHOT|M\\d+|RC\\d+))?\$"
 
     private static final Pattern SNAPSHOT_DASH = Pattern.compile('-SNAPSHOT$')
     private static final Pattern SNAPSHOT_DOT = Pattern.compile('\\.BUILD-SNAPSHOT$')
-    private static final Pattern MILESTONE_DASH = Pattern.compile('-(M\\d+)$')
-    private static final Pattern MILESTONE_DOT = Pattern.compile('\\.(M\\d+)$')
+    private static final Pattern MILESTONE_OR_RC_DASH = Pattern.compile('-(M\\d+|RC\\d+)$')
+    private static final Pattern MILESTONE_OR_RC_DOT = Pattern.compile('\\.(M\\d+|RC\\d+)$')
 
     static String sanitize(String version) {
         String v = version == null ? null : version.trim()
         if (v != null && v.matches(REGEX)) {
             return v
         }
-        throw new InvalidUserDataException("Invalid Spring Boot version '$version'. Expected x.y.z[.RELEASE|.M<N>|.BUILD-SNAPSHOT] or x.y.z[-M<N>|-SNAPSHOT].")
+        throw new InvalidUserDataException("Invalid Spring Boot version '$version'. Expected x.y.z[.RELEASE|.M<N>|.RC<N>|.BUILD-SNAPSHOT] or x.y.z[-M<N>|-RC<N>|-SNAPSHOT].")
     }
 
     static String toInitializr(String version) {
@@ -40,7 +40,7 @@ class BootVersionUtils {
             return out
         }
 
-        out = replaceIfMatches(version, MILESTONE_DASH, '.$1')
+        out = replaceIfMatches(version, MILESTONE_OR_RC_DASH, '.$1')
         if (out != null) {
             return out
         }
@@ -62,7 +62,7 @@ class BootVersionUtils {
             return out
         }
 
-        out = replaceIfMatches(version, MILESTONE_DOT, '-$1')
+        out = replaceIfMatches(version, MILESTONE_OR_RC_DOT, '-$1')
         if (out != null) {
             return out
         }

--- a/plugin/src/test/groovy/io/oczadly/internal/utils/BootVersionUtilsSpec.groovy
+++ b/plugin/src/test/groovy/io/oczadly/internal/utils/BootVersionUtilsSpec.groovy
@@ -17,6 +17,8 @@ class BootVersionUtilsSpec extends Specification {
                     '3.4.7.RELEASE',
                     '3.4.7-M1',
                     '3.4.7.M1',
+                    '4.1.0-RC1',
+                    '4.1.0.RC1',
                     '3.4.7.BUILD-SNAPSHOT',
                     '3.4.7-SNAPSHOT']
     }
@@ -30,7 +32,7 @@ class BootVersionUtilsSpec extends Specification {
         def ex = thrown InvalidUserDataException
 
         and:
-        ex.message == "Invalid Spring Boot version '$version'. Expected x.y.z[.RELEASE|.M<N>|.BUILD-SNAPSHOT] or x.y.z[-M<N>|-SNAPSHOT]."
+        ex.message == "Invalid Spring Boot version '$version'. Expected x.y.z[.RELEASE|.M<N>|.RC<N>|.BUILD-SNAPSHOT] or x.y.z[-M<N>|-RC<N>|-SNAPSHOT]."
 
         where:
         version << [null,


### PR DESCRIPTION
# Pull Request

## 🚀 What was changed

Adjusts the following according to Spring Initializr API changes:
* renames default class name to MyspringappApplication.
* adds handling the `RC` versions.

## ✅ Checklist

- [x] My change is **well-scoped** (one logical change).
- [x] I have **updated/added tests** if needed.
- [x] I have **updated the README/CHANGELOG** if needed.
- [x] I ran:
  ```bash
  ./gradlew build
  ```
- [x] I followed [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

## 🧩 Related issues (optional)

<!-- Link to relevant issues, e.g., Closes ... -->

n/a